### PR TITLE
changed invoice>items>name to item in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,11 +84,13 @@ If an error like ```No module named pypyant``` pops up, then the installation wa
    
    #Add an invoice for an existing user
    invoice.add(client_id=1,due_date="12/30/2016",fee_bearer="client",
-                items={
-                        "name": "Website Design",
+                items=[{
+                        "item": "Website Design",
                         "description": "5 Pages Website plus 1 Year Web Hosting",
                         "unit_cost": "50000.00",
-                        "quantity": "1")
+                        "quantity": "1"
+                        }]
+                        )
    
    #Add an invoice for a new user
    client = {
@@ -101,12 +103,13 @@ If an error like ```No module named pypyant``` pops up, then the installation wa
             "address": "Wase II"
             }
    invoice.add(new=True, client, due_date="12/30/2016",fee_bearer="client",
-                  items={
-                        "name": "Website Design",
+                  items=[{
+                        "item": "Website Design",
                         "description": "5 Pages Website plus 1 Year Web Hosting",
                         "unit_cost": "50000.00",
                         "quantity": "1" 
-                        }
+                        }]
+                        )
     
     
    #Get an invoice


### PR DESCRIPTION

The official docs has ```item``` as an items object variable and not ```name```. Using ```name``` returns ```(200, u'error', u"Atleast one of your invoice item's information is incomplete.")```.

The ```invoice>items``` is supposed to be a list of items(I learnt through support) - ```[{items_obj}, {items_obj}]```, thus I added square brackets. It returns ```(200, u'error', u"Atleast one of your invoice item's information is incomplete.")``` without the square brackets.
